### PR TITLE
[Feat] 스플래시 페이지 UI 구현

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "arcanis.vscode-zipfs",
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode"
   ]
 }

--- a/.yarn/sdks/prettier/bin/prettier.cjs
+++ b/.yarn/sdks/prettier/bin/prettier.cjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire, register} = require(`module`);
+const {resolve} = require(`path`);
+const {pathToFileURL} = require(`url`);
+
+const relPnpApiPath = "../../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
+const absRequire = createRequire(absPnpApiPath);
+
+const absPnpLoaderPath = resolve(absPnpApiPath, `../.pnp.loader.mjs`);
+const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require prettier/bin/prettier.cjs
+    require(absPnpApiPath).setup();
+    if (isPnpLoaderEnabled && register) {
+      register(pathToFileURL(absPnpLoaderPath));
+    }
+  }
+}
+
+const wrapWithUserWrapper = existsSync(absUserWrapperPath)
+  ? exports => absRequire(absUserWrapperPath)(exports)
+  : exports => exports;
+
+// Defer to the real prettier/bin/prettier.cjs your application uses
+module.exports = wrapWithUserWrapper(absRequire(`prettier/bin/prettier.cjs`));

--- a/.yarn/sdks/prettier/index.cjs
+++ b/.yarn/sdks/prettier/index.cjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire, register} = require(`module`);
+const {resolve} = require(`path`);
+const {pathToFileURL} = require(`url`);
+
+const relPnpApiPath = "../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
+const absRequire = createRequire(absPnpApiPath);
+
+const absPnpLoaderPath = resolve(absPnpApiPath, `../.pnp.loader.mjs`);
+const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require prettier
+    require(absPnpApiPath).setup();
+    if (isPnpLoaderEnabled && register) {
+      register(pathToFileURL(absPnpLoaderPath));
+    }
+  }
+}
+
+const wrapWithUserWrapper = existsSync(absUserWrapperPath)
+  ? exports => absRequire(absUserWrapperPath)(exports)
+  : exports => exports;
+
+// Defer to the real prettier your application uses
+module.exports = wrapWithUserWrapper(absRequire(`prettier`));

--- a/.yarn/sdks/prettier/package.json
+++ b/.yarn/sdks/prettier/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "prettier",
+  "version": "3.6.2-sdk",
+  "main": "./index.cjs",
+  "type": "commonjs",
+  "bin": "./bin/prettier.cjs"
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
-import HomePage from "@/pages/home/Homepage";
+// import Homepage from "./pages/home/Homepage";
+import SplashPage from "@/pages/splash/SplashPage";
 
 const App = () => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<HomePage />} />
+        {/* <Route path="/" element={<HomePage />} /> */}
+        <Route path="/" element={<SplashPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/QueryTest.tsx
+++ b/src/components/QueryTest.tsx
@@ -1,0 +1,10 @@
+const QueryTest = () => {
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">테스트용</h2>
+      <p>테스트 Component.</p>
+    </div>
+  );
+};
+
+export default QueryTest;

--- a/src/pages/splash/SplashPage.tsx
+++ b/src/pages/splash/SplashPage.tsx
@@ -1,15 +1,15 @@
 const SplashPage = () => {
   return (
-    <div className="min-h-screen bg-white flex justify-center items-center">
-      <div className="w-[394px] h-[852px] bg-white  flex flex-col relative">
-        <div className="flex-grow flex justify-center items-center">
-          <h1 className="text-[210%] font-bold text-black">나풀나풀</h1>
-        </div>
-        <div className="absolute bottom-10 w-full">
-          <p className="text-sm text-black text-center">
-            슬로건입니다. 더미텍스트입니다.
-          </p>
-        </div>
+    <div className="w-full h-screen bg-white flex flex-col relative">
+      <div className="flex-grow flex justify-center items-center">
+        <h1 className="text-[9vw] md:text-8xl font-bold text-black">
+          나풀나풀
+        </h1>
+      </div>
+      <div className="absolute bottom-10 w-full">
+        <p className="text-[4vw] md:text-2xl text-gray-500 text-center">
+          슬로건입니다. 더미텍스트입니다.
+        </p>
       </div>
     </div>
   );

--- a/src/pages/splash/SplashPage.tsx
+++ b/src/pages/splash/SplashPage.tsx
@@ -1,0 +1,18 @@
+const SplashPage = () => {
+  return (
+    <div className="min-h-screen bg-white flex justify-center items-center">
+      <div className="w-[394px] h-[852px] bg-white  flex flex-col relative">
+        <div className="flex-grow flex justify-center items-center">
+          <h1 className="text-[210%] font-bold text-black">나풀나풀</h1>
+        </div>
+        <div className="absolute bottom-10 w-full">
+          <p className="text-sm text-black text-center">
+            슬로건입니다. 더미텍스트입니다.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SplashPage;


### PR DESCRIPTION
### 💡 To Reviewers
- 해당 브랜치에서 새롭게 설치한 라이브러리가 있다면 함께 명시해 주세요.
  없습니다 ~!
  
- 리뷰어가 코드를 이해하는 데 도움이 되는 정보나 참고사항이 있다면 자유롭게 작성해 주세요.
   `w-full h-screen`: 전체 화면 너비와 높이를 사용합니다.
   `text-[12vw] md:text-8xl`: "나풀나풀" 텍스트는 화면 너비의 12% 크기로 설정되지만, 중간 크기 화면(768px) 이상에서는 8xl 크기(96px)  로 고정됩니다.
   `text-[4vw] md:text-2xl`: 슬로건 텍스트는 화면 너비의 4% 크기로 설정되지만, 중간 크기 화면 이상에서는 2xl 크기(24px)로 고정됩니다.
  
### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- pages/splash/SplashPage.tsx 에서 SplashPage UI 구현
    
### 🤔 추후 작업 예정
- 추가 구현이 필요한 부분이나 다음 작업 계획을 작성해 주세요.
  Splash 에서 몇 초 후에 HomePage로 가는 로직 구현.

### 📸 작업 결과 (스크린샷)
- 작업 결과를 보여주는 스크린샷을 첨부해 주세요.
<img width="666" height="862" alt="아이폰 12 pro" src="https://github.com/user-attachments/assets/0fa20673-661b-4f8b-8388-b380fe1d38ff" />
<img width="656" height="865" alt="아이패드 pro" src="https://github.com/user-attachments/assets/59842033-b777-4cc0-b94b-ada0d4a8fd20" />
<img width="792" height="638" alt="갤럭시 Z fold 5" src="https://github.com/user-attachments/assets/6cb7c633-9b61-4e64-903b-37ecbdb5a20c" />


### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
#3 
