### PR TITLE
[Feat] 온보딩 UI 구현

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -56,6 +56,7 @@ const RAW_RUNTIME_STATE =
           ["react", "npm:19.1.0"],\
           ["react-dom", "virtual:a26df681d8f5cb886104bc63845e90f74ff917ae53e0ae4622b7df50bf61ef86383bf875b5dd214089733dd74f1e7aa37ddc1b4f7c3a8adab11cd2d56ad5a4b3#npm:19.1.0"],\
           ["react-router-dom", "virtual:a26df681d8f5cb886104bc63845e90f74ff917ae53e0ae4622b7df50bf61ef86383bf875b5dd214089733dd74f1e7aa37ddc1b4f7c3a8adab11cd2d56ad5a4b3#npm:7.6.3"],\
+          ["swiper", "npm:11.2.10"],\
           ["tailwindcss", "npm:4.1.11"],\
           ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"],\
           ["typescript-eslint", "virtual:a26df681d8f5cb886104bc63845e90f74ff917ae53e0ae4622b7df50bf61ef86383bf875b5dd214089733dd74f1e7aa37ddc1b4f7c3a8adab11cd2d56ad5a4b3#npm:8.35.1"],\
@@ -3391,6 +3392,7 @@ const RAW_RUNTIME_STATE =
           ["react", "npm:19.1.0"],\
           ["react-dom", "virtual:a26df681d8f5cb886104bc63845e90f74ff917ae53e0ae4622b7df50bf61ef86383bf875b5dd214089733dd74f1e7aa37ddc1b4f7c3a8adab11cd2d56ad5a4b3#npm:19.1.0"],\
           ["react-router-dom", "virtual:a26df681d8f5cb886104bc63845e90f74ff917ae53e0ae4622b7df50bf61ef86383bf875b5dd214089733dd74f1e7aa37ddc1b4f7c3a8adab11cd2d56ad5a4b3#npm:7.6.3"],\
+          ["swiper", "npm:11.2.10"],\
           ["tailwindcss", "npm:4.1.11"],\
           ["typescript", "patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"],\
           ["typescript-eslint", "virtual:a26df681d8f5cb886104bc63845e90f74ff917ae53e0ae4622b7df50bf61ef86383bf875b5dd214089733dd74f1e7aa37ddc1b4f7c3a8adab11cd2d56ad5a4b3#npm:8.35.1"],\
@@ -4938,6 +4940,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/svg-parser-npm-2.0.4-1b0b6afbe9-02f6cb155d.zip/node_modules/svg-parser/",\
         "packageDependencies": [\
           ["svg-parser", "npm:2.0.4"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["swiper", [\
+      ["npm:11.2.10", {\
+        "packageLocation": "./.yarn/cache/swiper-npm-11.2.10-2bf88a66cf-b7e3a7c79d.zip/node_modules/swiper/",\
+        "packageDependencies": [\
+          ["swiper", "npm:11.2.10"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "arcanis.vscode-zipfs",
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode"
   ]
 }

--- a/.yarn/sdks/prettier/bin/prettier.cjs
+++ b/.yarn/sdks/prettier/bin/prettier.cjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire, register} = require(`module`);
+const {resolve} = require(`path`);
+const {pathToFileURL} = require(`url`);
+
+const relPnpApiPath = "../../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
+const absRequire = createRequire(absPnpApiPath);
+
+const absPnpLoaderPath = resolve(absPnpApiPath, `../.pnp.loader.mjs`);
+const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require prettier/bin/prettier.cjs
+    require(absPnpApiPath).setup();
+    if (isPnpLoaderEnabled && register) {
+      register(pathToFileURL(absPnpLoaderPath));
+    }
+  }
+}
+
+const wrapWithUserWrapper = existsSync(absUserWrapperPath)
+  ? exports => absRequire(absUserWrapperPath)(exports)
+  : exports => exports;
+
+// Defer to the real prettier/bin/prettier.cjs your application uses
+module.exports = wrapWithUserWrapper(absRequire(`prettier/bin/prettier.cjs`));

--- a/.yarn/sdks/prettier/index.cjs
+++ b/.yarn/sdks/prettier/index.cjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const {existsSync} = require(`fs`);
+const {createRequire, register} = require(`module`);
+const {resolve} = require(`path`);
+const {pathToFileURL} = require(`url`);
+
+const relPnpApiPath = "../../../.pnp.cjs";
+
+const absPnpApiPath = resolve(__dirname, relPnpApiPath);
+const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
+const absRequire = createRequire(absPnpApiPath);
+
+const absPnpLoaderPath = resolve(absPnpApiPath, `../.pnp.loader.mjs`);
+const isPnpLoaderEnabled = existsSync(absPnpLoaderPath);
+
+if (existsSync(absPnpApiPath)) {
+  if (!process.versions.pnp) {
+    // Setup the environment to be able to require prettier
+    require(absPnpApiPath).setup();
+    if (isPnpLoaderEnabled && register) {
+      register(pathToFileURL(absPnpLoaderPath));
+    }
+  }
+}
+
+const wrapWithUserWrapper = existsSync(absUserWrapperPath)
+  ? exports => absRequire(absUserWrapperPath)(exports)
+  : exports => exports;
+
+// Defer to the real prettier your application uses
+module.exports = wrapWithUserWrapper(absRequire(`prettier`));

--- a/.yarn/sdks/prettier/package.json
+++ b/.yarn/sdks/prettier/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "prettier",
+  "version": "3.6.2-sdk",
+  "main": "./index.cjs",
+  "type": "commonjs",
+  "bin": "./bin/prettier.cjs"
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.3",
+    "swiper": "^11.2.10",
     "zustand": "^5.0.6"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,15 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 // import Homepage from "./pages/home/Homepage";
 import SplashPage from "@/pages/splash/SplashPage";
 
+import OnboardingPage from "./pages/onboarding/OnboardingPage";
+
 const App = () => {
   return (
     <BrowserRouter>
       <Routes>
         {/* <Route path="/" element={<HomePage />} /> */}
         <Route path="/" element={<SplashPage />} />
+        <Route path="/onboarding" element={<OnboardingPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
-import HomePage from "@/pages/home/Homepage";
+// import Homepage from "./pages/home/Homepage";
+import SplashPage from "@/pages/splash/SplashPage";
 
 const App = () => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<HomePage />} />
+        {/* <Route path="/" element={<HomePage />} /> */}
+        <Route path="/" element={<SplashPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/QueryTest.tsx
+++ b/src/components/QueryTest.tsx
@@ -1,0 +1,10 @@
+const QueryTest = () => {
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">테스트용</h2>
+      <p>테스트 Component.</p>
+    </div>
+  );
+};
+
+export default QueryTest;

--- a/src/pages/onboarding/OnboardingPage.tsx
+++ b/src/pages/onboarding/OnboardingPage.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+
+import { Swiper, SwiperSlide } from "swiper/react";
+
+import "swiper/css";
+
+const OnboardingPage = () => {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const handleSlideChange = (swiper) => {
+    setActiveIndex(swiper.activeIndex);
+  };
+
+  return (
+    <div className="w-full h-screen bg-white flex flex-col">
+      {/* 모션 그래픽 영역 ( 디자인 나오면 수정 예정 ) */}
+      <div className="w-full h-2/3 bg-gray-100 border-b-2 border-dashed border-gray-400 flex justify-center items-center">
+        <p className="text-gray-500">모션 그래픽 영역</p>
+      </div>
+
+      {/* 온보딩 영역 */}
+      <div className="flex-1 flex flex-col">
+        <Swiper onSlideChange={handleSlideChange} className="w-full h-full">
+          <SwiperSlide className="flex items-center justify-center h-full pt-[15%]">
+            <p className="text-2xl font-semibold text-center">
+              나만의 식물을 <br />
+              화면 속에서 만나보세요.
+            </p>
+          </SwiperSlide>
+          <SwiperSlide className="flex items-center justify-center h-full pt-[15%]">
+            <p className="text-2xl font-semibold text-center">
+              미션을 수행하고, <br />
+              아바타를 꾸며보세요.
+            </p>
+          </SwiperSlide>
+          <SwiperSlide className="flex items-center justify-center h-full pt-[15%] ">
+            <p className="text-2xl font-semibold text-center">
+              친구들의 식물 아바타와
+              <br /> 재미있는 게임을 해보세요.
+            </p>
+          </SwiperSlide>
+        </Swiper>
+
+        <div className="p-6">
+          {/* Pagination and Hint */}
+          <div className="flex flex-col items-center">
+            <div className="flex space-x-2 my-4">
+              {[0, 1, 2].map((index) => (
+                <div
+                  key={index}
+                  className={`w-3 h-3 rounded-full ${activeIndex === index ? "bg-black" : "bg-gray-300"}`}
+                />
+              ))}
+            </div>
+            <div className="bg-[#f3f3f3] px-4 py-1 ">
+              <p className="text-sm text-gray-600">좌우로 넘길 수 있어요</p>
+            </div>
+          </div>
+        </div>
+
+        {/* CTA Button */}
+        <button
+          className={`w-full py-5  font-bold ${
+            activeIndex === 2
+              ? "bg-[#7f7f7f] cursor-pointer text-white"
+              : "bg-[#f3f3f3] cursor-not-allowed text-[#bfbfbf]"
+          }`}
+          disabled={activeIndex !== 2}
+        >
+          나만의 화단 만들러 가기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default OnboardingPage;

--- a/src/pages/splash/SplashPage.tsx
+++ b/src/pages/splash/SplashPage.tsx
@@ -1,15 +1,15 @@
 const SplashPage = () => {
   return (
-    <div className="min-h-screen bg-white flex justify-center items-center">
-      <div className="w-[394px] h-[852px] bg-white  flex flex-col relative">
-        <div className="flex-grow flex justify-center items-center">
-          <h1 className="text-[210%] font-bold text-black">나풀나풀</h1>
-        </div>
-        <div className="absolute bottom-10 w-full">
-          <p className="text-sm text-black text-center">
-            슬로건입니다. 더미텍스트입니다.
-          </p>
-        </div>
+    <div className="w-full h-screen bg-white flex flex-col relative">
+      <div className="flex-grow flex justify-center items-center">
+        <h1 className="text-[9vw] md:text-8xl font-bold text-black">
+          나풀나풀
+        </h1>
+      </div>
+      <div className="absolute bottom-10 w-full">
+        <p className="text-[4vw] md:text-2xl text-gray-500 text-center">
+          슬로건입니다. 더미텍스트입니다.
+        </p>
       </div>
     </div>
   );

--- a/src/pages/splash/SplashPage.tsx
+++ b/src/pages/splash/SplashPage.tsx
@@ -1,0 +1,18 @@
+const SplashPage = () => {
+  return (
+    <div className="min-h-screen bg-white flex justify-center items-center">
+      <div className="w-[394px] h-[852px] bg-white  flex flex-col relative">
+        <div className="flex-grow flex justify-center items-center">
+          <h1 className="text-[210%] font-bold text-black">나풀나풀</h1>
+        </div>
+        <div className="absolute bottom-10 w-full">
+          <p className="text-sm text-black text-center">
+            슬로건입니다. 더미텍스트입니다.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SplashPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,6 +2600,7 @@ __metadata:
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
     react-router-dom: "npm:^7.6.3"
+    swiper: "npm:^11.2.10"
     tailwindcss: "npm:^4.1.11"
     typescript: "npm:~5.8.3"
     typescript-eslint: "npm:^8.34.1"
@@ -4002,6 +4003,13 @@ __metadata:
   version: 2.0.4
   resolution: "svg-parser@npm:2.0.4"
   checksum: 10c0/02f6cb155dd7b63ebc2f44f36365bc294543bebb81b614b7628f1af3c54ab64f7e1cec20f06e252bf95bdde78441ae295a412c68ad1678f16a6907d924512b7a
+  languageName: node
+  linkType: hard
+
+"swiper@npm:^11.2.10":
+  version: 11.2.10
+  resolution: "swiper@npm:11.2.10"
+  checksum: 10c0/b7e3a7c79d92ccc62af77744edc376c9aefc771a0abd50c4adf07b5e3450b5da9ca7f84f5809e275ff65e1bc9d4500d930628e84a76fc7f2db403291c69b7fac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### 💡 To Reviewers
- 해당 브랜치에서 새롭게 설치한 라이브러리가 있다면 함께 명시해 주세요.
  yarn add swiper 설치
    앱 (핸드폰) 에서 좌/우로 넘기기 위한 라이브러리
- 리뷰어가 코드를 이해하는 데 도움이 되는 정보나 참고사항이 있다면 자유롭게 작성해 주세요.
  Swiper: 전체 슬라이드(또는 캐러셀)를 감싸는 컨테이너 컴포넌트입니다.
             여기에 스와이프 동작, 자동 넘김 등 다양한 옵션을 설정할 수 있습니다.
  SwiperSlide: Swiper 내부에 들어가는 각각의 개별 슬라이드(페이지)를 의미합니다. 
             사용자가 넘기는 한 장 한 장의 화면이 SwiperSlide입니다.
  Swiper 라이브러리에 내장되어 있는 CSS로 인해서 Swiper내에 있는 문장 ( ex. 친구들의 식물 아바타와 <br/>재미있는 게임을 해보세요) 은 pt-[15%] 로 했습니다. ( 디바이스를 바꿔도 UI가 깨지거나 하지는 않았습니다. )
             
### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- 온보딩 UI 구현
- Swiper를 활용하여 좌우로 넘기는 기능 구현
- 모두 넘겼을 때 버튼 활성화 구현

### 🤔 추후 작업 예정
- 추가 구현이 필요한 부분이나 다음 작업 계획을 작성해 주세요.
  나만의 화단 만들러 가기 버튼 클릭 시, 유저등록 페이지 이동하는 기능 구현
  
### 📸 작업 결과 (스크린샷)
- 작업 결과를 보여주는 스크린샷을 첨부해 주세요.
<img width="765" height="863" alt="스크린샷 2025-07-11 144424" src="https://github.com/user-attachments/assets/0884e8b6-bdcf-46f0-a350-082e2309d0aa" />
<img width="671" height="867" alt="스크린샷 2025-07-11 144440" src="https://github.com/user-attachments/assets/1876f633-5bbe-40d4-a29d-605fdd05de47" />


### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
#5 
