### PR TITLE
[Feat] CreationDetailPage에서 다음 버튼 클릭 시 아바타 생성 페이지의 버튼 바뀌도록 구현

### DIFF
--- a/src/components/registration/avatarCreation/AvatarCreationOption.tsx
+++ b/src/components/registration/avatarCreation/AvatarCreationOption.tsx
@@ -8,9 +8,11 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 
 import Button from "@/components/common/Button";
+import { useAvatarCreationStore } from "@/stores/avatarCreationStore";
 
 const AvatarCreationOption = () => {
   const navigate = useNavigate();
+  const { buttonVariant, buttonText } = useAvatarCreationStore();
 
   const handleNavigate = () => {
     navigate("/registration/creation-detail");
@@ -26,8 +28,12 @@ const AvatarCreationOption = () => {
           </p>
         </div>
         <div className="pb-10.25">
-          <Button variant="primary" size="xsCreation" onClick={handleNavigate}>
-            만들러 가기
+          <Button
+            variant={buttonVariant}
+            size="xsCreation"
+            onClick={handleNavigate}
+          >
+            {buttonText}
           </Button>
         </div>
       </div>

--- a/src/pages/registration/CreationDetailPage.tsx
+++ b/src/pages/registration/CreationDetailPage.tsx
@@ -1,10 +1,21 @@
 import React from "react";
 
+import { useNavigate } from "react-router-dom";
+
 import Button from "@/components/common/Button";
 import RegistrationHeader from "@/components/registration/common/RegistrationHeader";
 import CreationDetail from "@/components/registration/creationFlow/CreationDetail";
+import { useAvatarCreationStore } from "@/stores/avatarCreationStore";
 
 const CreationDetailPage = () => {
+  const navigate = useNavigate();
+  const { setButtonState } = useAvatarCreationStore();
+
+  const handleNextClick = () => {
+    setButtonState("gray200", "다시 만들기");
+    navigate("/registration/avatar");
+  };
+
   return (
     <div className="flex flex-col h-screen">
       <RegistrationHeader showBackButton={false} />
@@ -12,7 +23,7 @@ const CreationDetailPage = () => {
         <CreationDetail />
       </main>
       <footer className="flex items-center justify-center pb-5.25">
-        <Button variant="primary" size="lg">
+        <Button variant="primary" size="lg" onClick={handleNextClick}>
           다음
         </Button>
       </footer>

--- a/src/stores/avatarCreationStore.ts
+++ b/src/stores/avatarCreationStore.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+interface AvatarCreationState {
+  buttonVariant: "primary" | "gray200" | "gray600";
+  buttonText: string;
+  setButtonState: (
+    variant: "primary" | "gray200" | "gray600",
+    text: string
+  ) => void;
+}
+
+export const useAvatarCreationStore = create<AvatarCreationState>(set => ({
+  buttonVariant: "primary",
+  buttonText: "만들러 가기",
+  setButtonState: (variant, text) =>
+    set({ buttonVariant: variant, buttonText: text }),
+}));


### PR DESCRIPTION
### 💡 To Reviewers
- 해당 브랜치에서 새롭게 설치한 라이브러리가 있다면 함께 명시해 주세요.
없습니다.

- 리뷰어가 코드를 이해하는 데 도움이 되는 정보나 참고사항이 있다면 자유롭게 작성해 주세요.
zustand 를 사용하여 Button의 상태가 바뀌도록 구현했습니다.


### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- zustand를 사용하여 AvatarCreationPage.tsx의 버튼 상태(variant, text)를 관리할 전역 상태를 정의 
- react-router-dom의 useNavigate 훅을 사용하여 CreationDetailPage.tsx에서 AvatarCreationPage.tsx로 이동
이때, 상태를 함께 전달할 수 있도록 함.
- AvatarCreationOption.tsx 내의 Button 컴포넌트가 전역 상태에 따라 variant와 text를 동적으로 변경하도록 수정


### 🤔 추후 작업 예정
- 다시 만들기가 된 AvatarCreationOption.tsx 를 클릭 할 시에 AvatarCreationPage의 ButtonFooter의 다음 버튼이 활성화 되도록 함.

### 📸 작업 결과 (스크린샷)
- 작업 결과를 보여주는

https://github.com/user-attachments/assets/738a68da-8dcd-4cad-b1b0-c66fc22ee9e1

 스크린샷을 첨부해 주세요.

### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: #2
#14 