### PR TITLE
[Refactor/Design] 등록 페이지 Header의 border-b 추가 및 ButtonFooter 에 padding-b 추가

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -26,7 +26,8 @@ const Button: React.FC<ButtonProps> = ({
   className,
   ...props
 }) => {
-  const baseStyles = "flex items-center justify-center text-center rounded "; // 공통 스타일
+  const baseStyles =
+    "flex items-center justify-center text-center rounded-[8px] "; // 공통 스타일
 
   const sizeStyles = {
     xsSelect: "w-34.5 h-11.25 text-[18px] px-5 py-2",

--- a/src/components/registration/avatarCreation/AvatarSelectionOption.tsx
+++ b/src/components/registration/avatarCreation/AvatarSelectionOption.tsx
@@ -9,7 +9,7 @@ import Button from "@/components/common/Button";
 
 const AvatarCreationOption = () => {
   return (
-    <div className="flex items-center justify-between h-full">
+    <div className="flex items-center justify-between h-full border-b-2 border-[var(--color-gray-200)]">
       <div className="flex flex-col justify-between pl-6.25 h-full">
         <div className="flex flex-col gap-3 w-38.75">
           <h2 className="text-2xl font-semibold pt-8">아바타 선택</h2>

--- a/src/components/registration/common/ButtonFooter.tsx
+++ b/src/components/registration/common/ButtonFooter.tsx
@@ -8,9 +8,11 @@ import Button from "@/components/common/Button";
 
 const ButtonFooter = () => {
   return (
-    <footer className="flex justify-evenly bg-white h-14.25">
-      <Button variant="gray200">나중에하기</Button>
-      <Button variant="gray600">다음</Button>
+    <footer className="pb-5.25">
+      <div className="flex justify-evenly bg-white h-14.25">
+        <Button variant="gray200">나중에하기</Button>
+        <Button variant="gray600">다음</Button>
+      </div>
     </footer>
   );
 };

--- a/src/components/registration/common/RegistrationHeader.tsx
+++ b/src/components/registration/common/RegistrationHeader.tsx
@@ -20,7 +20,7 @@ const RegistrationHeader = ({
   };
 
   return (
-    <header className="h-14 flex items-center justify-between p-3.5 bg-white border-b-gray-200">
+    <header className="h-14 flex items-center justify-between p-3.5 bg-white border-b-1 border-[var(--color-gray-200)]">
       {showBackButton ? (
         <button onClick={handleBack}>
           <img src={Left} alt="뒤로가기" className="w-6 h-6" />

--- a/src/pages/registration/AvatarCreationPage.tsx
+++ b/src/pages/registration/AvatarCreationPage.tsx
@@ -23,6 +23,7 @@ const AvatarPage = () => {
           <AvatarCreationOption />
         </div>
       </main>
+
       <ButtonFooter />
     </div>
   );


### PR DESCRIPTION
### 💡 To Reviewers
- 해당 브랜치에서 새롭게 설치한 라이브러리가 있다면 함께 명시해 주세요.
없습니다.
- 리뷰어가 코드를 이해하는 데 도움이 되는 정보나 참고사항이 있다면 자유롭게 작성해 주세요.
ButtonFooter에 자체적으로 padding-b이 들어가도록 구현했습니다. 따라서 Footer 구현 시에 컴포넌트만 끌어쓰면 됩니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- RegistrationHeader에 border-b 추가
- ButtonFooter 에 자체적으로 padding-b 추가

### 🤔 추후 작업 예정
- 추가 구현이 필요한 부분이나 다음 작업 계획을 작성해 주세요.
- 별명 짓기에서 별명입력 후에 버튼 스타일 바꾸기 (내 텃밭으로 가기)

### 📸 작업 결과 (스크린샷)
- 작업 결과를 보여주는 스크린샷을 첨부해 주세요.
- 
<img width="387" height="811" alt="image" src="https://github.com/user-attachments/assets/6a0ace4b-c498-4547-8b62-ad6875abda0d" />
<img width="381" height="804" alt="image" src="https://github.com/user-attachments/assets/cdccfa83-c7de-4284-be16-4ba6f0ec80da" />


### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: #2
- #18 
