### PR TITLE
[Feat] 아바타 선택 완료 시 상태 변화 및 별명 짓기 페이지로 전환

### DIFF
--- a/src/components/registration/avatarCreation/AvatarCreationOption.tsx
+++ b/src/components/registration/avatarCreation/AvatarCreationOption.tsx
@@ -2,7 +2,6 @@
  * @file AvatarCreationOption.tsx
  * @description 아바타 생성 페이지의 옵션 컴포넌트
  */
-
 import React from "react";
 
 import { useNavigate } from "react-router-dom";
@@ -10,34 +9,58 @@ import { useNavigate } from "react-router-dom";
 import Button from "@/components/common/Button";
 import { useAvatarCreationStore } from "@/stores/avatarCreationStore";
 
-const AvatarCreationOption = () => {
-  const navigate = useNavigate();
-  const { buttonVariant, buttonText } = useAvatarCreationStore();
+interface AvatarCreationOptionProps {
+  optionId: string;
+}
 
-  const handleNavigate = () => {
+const AvatarCreationOption: React.FC<AvatarCreationOptionProps> = ({
+  optionId,
+}) => {
+  const navigate = useNavigate();
+  const { mode, selectedOptionId, actions } = useAvatarCreationStore();
+
+  const isSelected = selectedOptionId === optionId;
+
+  // 컨테이너 클릭 핸들러: 'remake' 모드일 때만 클릭 이벤트를 처리함.
+  const handleContainerClick = () => {
+    if (mode === "remake") {
+      actions.selectOption(optionId);
+    }
+  };
+
+  // 버튼 클릭 핸들러: 항상 페이지를 이동시키도록 함.
+  const handleButtonClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
     navigate("/registration/creation-detail");
   };
 
   return (
-    <div className="flex items-center justify-between h-full">
+    <div
+      className={`flex items-center justify-between h-full  ${
+        isSelected
+          ? "bg-[var(--color-primary-varient)] border-none"
+          : "border-transparent"
+      } ${mode === "remake" ? "cursor-pointer" : "cursor-default"}`}
+      onClick={handleContainerClick}
+    >
       <div className="flex flex-col justify-between pl-6.25 h-full">
         <div className="flex flex-col gap-3 w-41.25 text-left">
           <h2 className="text-2xl font-semibold pt-8">나만의 아바타</h2>
-          <p className="text-lg ">
+          <p className="text-lg">
             내 식물의 생김새를 반영한 나만의 아바타를 만들 수 있어요
           </p>
         </div>
         <div className="pb-10.25">
           <Button
-            variant={buttonVariant}
+            variant={mode === "initial" ? "primary" : "gray200"}
             size="xsCreation"
-            onClick={handleNavigate}
+            onClick={handleButtonClick}
           >
-            {buttonText}
+            {mode === "initial" ? "만들러 가기" : "다시 만들기"}
           </Button>
         </div>
       </div>
-      <div className="w-1/2 h-full "></div>
+      <div className="w-1/2 h-full"></div>
     </div>
   );
 };

--- a/src/components/registration/avatarCreation/AvatarCreationOption.tsx
+++ b/src/components/registration/avatarCreation/AvatarCreationOption.tsx
@@ -21,7 +21,7 @@ const AvatarCreationOption = () => {
   return (
     <div className="flex items-center justify-between h-full">
       <div className="flex flex-col justify-between pl-6.25 h-full">
-        <div className="flex flex-col gap-3 w-41.25">
+        <div className="flex flex-col gap-3 w-41.25 text-left">
           <h2 className="text-2xl font-semibold pt-8">나만의 아바타</h2>
           <p className="text-lg ">
             내 식물의 생김새를 반영한 나만의 아바타를 만들 수 있어요

--- a/src/components/registration/avatarCreation/AvatarSelectionOption.tsx
+++ b/src/components/registration/avatarCreation/AvatarSelectionOption.tsx
@@ -11,7 +11,7 @@ const AvatarCreationOption = () => {
   return (
     <div className="flex items-center justify-between h-full border-b-2 border-[var(--color-gray-200)]">
       <div className="flex flex-col justify-between pl-6.25 h-full">
-        <div className="flex flex-col gap-3 w-38.75">
+        <div className="flex flex-col gap-3 w-38.75 text-left">
           <h2 className="text-2xl font-semibold pt-8">아바타 선택</h2>
           <p className="text-lg ">00종의 아바타 중에서 선택할 수 있어요</p>
         </div>

--- a/src/components/registration/common/ButtonFooter.tsx
+++ b/src/components/registration/common/ButtonFooter.tsx
@@ -6,12 +6,26 @@ import React from "react";
 
 import Button from "@/components/common/Button";
 
-const ButtonFooter = () => {
+interface ButtonFooterProps {
+  nextButtonVariant: "primary" | "gray200" | "gray600";
+  onNextClick?: () => void;
+}
+
+const ButtonFooter: React.FC<ButtonFooterProps> = ({
+  nextButtonVariant,
+  onNextClick,
+}) => {
   return (
     <footer className="pb-5.25">
       <div className="flex justify-evenly bg-white h-14.25">
         <Button variant="gray200">나중에하기</Button>
-        <Button variant="gray600">다음</Button>
+        <Button
+          variant={nextButtonVariant}
+          onClick={onNextClick}
+          disabled={nextButtonVariant === "gray600"}
+        >
+          다음
+        </Button>
       </div>
     </footer>
   );

--- a/src/pages/registration/AvatarCreationPage.tsx
+++ b/src/pages/registration/AvatarCreationPage.tsx
@@ -5,12 +5,24 @@
 
 import React from "react";
 
+import { useNavigate } from "react-router-dom";
+
 import AvatarCreationOption from "@/components/registration/avatarCreation/AvatarCreationOption";
 import AvatarSelectionOption from "@/components/registration/avatarCreation/AvatarSelectionOption";
 import ButtonFooter from "@/components/registration/common/ButtonFooter";
 import RegistrationHeader from "@/components/registration/common/RegistrationHeader";
+import { useAvatarCreationStore } from "@/stores/avatarCreationStore";
 
-const AvatarPage = () => {
+const AvatarCreationPage = () => {
+  const { selectedOptionId } = useAvatarCreationStore();
+  const navigate = useNavigate();
+
+  const handleNextClick = () => {
+    if (selectedOptionId) {
+      navigate("/registration/plant-nickname");
+    }
+  };
+
   return (
     <div className="flex flex-col h-screen">
       <RegistrationHeader />
@@ -19,14 +31,17 @@ const AvatarPage = () => {
           <AvatarSelectionOption />
         </button>
 
-        <button className="flex-1">
-          <AvatarCreationOption />
-        </button>
+        <div className="flex-1">
+          <AvatarCreationOption optionId="creation" />
+        </div>
       </main>
 
-      <ButtonFooter />
+      <ButtonFooter
+        nextButtonVariant={selectedOptionId ? "primary" : "gray600"}
+        onNextClick={handleNextClick}
+      />
     </div>
   );
 };
 
-export default AvatarPage;
+export default AvatarCreationPage;

--- a/src/pages/registration/AvatarCreationPage.tsx
+++ b/src/pages/registration/AvatarCreationPage.tsx
@@ -15,13 +15,13 @@ const AvatarPage = () => {
     <div className="flex flex-col h-screen">
       <RegistrationHeader />
       <main className="flex-grow flex flex-col min-h-0">
-        <div className="flex-1">
+        <button className="flex-1">
           <AvatarSelectionOption />
-        </div>
+        </button>
 
-        <div className="flex-1">
+        <button className="flex-1">
           <AvatarCreationOption />
-        </div>
+        </button>
       </main>
 
       <ButtonFooter />

--- a/src/pages/registration/CreationDetailPage.tsx
+++ b/src/pages/registration/CreationDetailPage.tsx
@@ -9,10 +9,12 @@ import { useAvatarCreationStore } from "@/stores/avatarCreationStore";
 
 const CreationDetailPage = () => {
   const navigate = useNavigate();
-  const { setButtonState } = useAvatarCreationStore();
+  const { setButtonState, setIsAvatarOptionSelected } =
+    useAvatarCreationStore();
 
   const handleNextClick = () => {
     setButtonState("gray200", "다시 만들기");
+    setIsAvatarOptionSelected(true);
     navigate("/registration/avatar");
   };
 

--- a/src/pages/registration/CreationDetailPage.tsx
+++ b/src/pages/registration/CreationDetailPage.tsx
@@ -9,12 +9,10 @@ import { useAvatarCreationStore } from "@/stores/avatarCreationStore";
 
 const CreationDetailPage = () => {
   const navigate = useNavigate();
-  const { setButtonState, setIsAvatarOptionSelected } =
-    useAvatarCreationStore();
+  const { actions } = useAvatarCreationStore();
 
   const handleNextClick = () => {
-    setButtonState("gray200", "다시 만들기");
-    setIsAvatarOptionSelected(true);
+    actions.completeInitialCreation();
     navigate("/registration/avatar");
   };
 

--- a/src/stores/avatarCreationStore.ts
+++ b/src/stores/avatarCreationStore.ts
@@ -1,38 +1,54 @@
+/**
+ * @file avatarCreationStore.ts
+ * @description AvatarCreation 컴포넌트의 상태를 관리하는 Zustand 스토어입니다.
+ *              새로운 기능추가 시 이 파일을 수정.
+ * @version 1.0.0
+ * @data 2023-08-04
+ */
+
 import { create } from "zustand";
 
 /**
- * @interface AvatarCreationState
- * @description AvatarCreation 컴포넌트의 상태를 관리하는 인터페이스.
- * @property {string} buttonVariant - 버튼의 변형 스타일 ("primary", "gray200", "gray600")
- * @property {string} buttonText - 버튼에 표시될 텍스트
- * @property {function} setButtonState - 버튼 상태를 설정하는 함수 (variant: "primary" | "gray200" | "gray600", text: string)
- * @property {boolean} isAvatarOptionSelected - 아바타 옵션이 선택되었는지 여부 (true: 선택됨, false: 선택되지 않음)
- * @property {function} setIsAvatarOptionSelected - 아바타 옵션 선택 상태를 설정하는 함수 (setIsAvatarOptionSelected(true | false))
- * @example - const { buttonVariant, buttonText, setButtonState, isAvatarOptionSelected, setIsAvatarOptionSelected } = useAvatarCreationStore();
+ * @description 아바타 생성 플로우의 전체 상태
+ * @property {'initial' | 'remake'} mode - 'initial': 최초 생성, 'remake': 다시 만들기
+ * @property {string | null} selectedOptionId - 선택된 아바타 옵션의 ID.
+ * @property {object} actions - 상태를 변경하는 함수들의 네임스페이스
  */
 interface AvatarCreationState {
-  buttonVariant: "primary" | "gray200" | "gray600";
-  buttonText: string;
-  setButtonState: (
-    variant: "primary" | "gray200" | "gray600",
-    text: string
-  ) => void;
-  isAvatarOptionSelected: boolean;
-  setIsAvatarOptionSelected: (isSelected: boolean) => void;
+  mode: "initial" | "remake";
+  selectedOptionId: string | null;
+  actions: {
+    completeInitialCreation: () => void;
+    selectOption: (optionId: string) => void;
+    reset: () => void;
+  };
 }
 
 /**
- * @function useAvatarCreationStore
- * @description AvatarCreation 컴포넌트의 상태를 관리하는 Zustand 스토어 훅.
- * @returns {AvatarCreationState} AvatarCreation 컴포넌트의 상태와 상태를 변경하는 함수들을 포함하는 객체.
- * @example - const { buttonVariant, buttonText, setButtonState, isAvatarOptionSelected, setIsAvatarOptionSelected } = useAvatarCreationStore();
+ * @description 아바타 생성 플로우의 상태를 관리하는 Zustand 스토어.
+ *
+ * @example
+ * const { mode, selectedOptionId, actions } = useAvatarCreationStore();
+ * actions.selectOption('some-option-id');
+ *
+ * @mode {'initial' | 'remake'} - 현재 모드. 'initial'은 최초 생성, 'remake'는 다시 만들기 모드입니다.
+ * @selectedOptionId {string | null} - 현재 선택된 아바타 옵션의 ID. 선택되지 않은 경우 null입니다.
+ * @action completeInitialCreation - set({ mode: 'remake', selectedOptionId: null }) => '다시 만들기' 모드로 전환합니다.
+ * @action selectOption - set({ selectedOptionId: optionId }) => 사용자가 아바타 옵션을 선택합니다.
+ * @action reset - set({ mode: 'initial', selectedOptionId: null }) => 모든 상태를 초기값으로 리셋합니다.
  */
 export const useAvatarCreationStore = create<AvatarCreationState>(set => ({
-  buttonVariant: "primary",
-  buttonText: "만들러 가기",
-  setButtonState: (variant, text) =>
-    set({ buttonVariant: variant, buttonText: text }),
-  isAvatarOptionSelected: false,
-  setIsAvatarOptionSelected: (isSelected: boolean) =>
-    set({ isAvatarOptionSelected: isSelected }),
+  mode: "initial",
+  selectedOptionId: null,
+  actions: {
+    /** 최초 생성 플로우를 완료하고 '다시 만들기' 모드로 전환합니다. */
+    completeInitialCreation: () =>
+      set({ mode: "remake", selectedOptionId: null }),
+
+    /** 사용자가 아바타 옵션을 선택합니다. */
+    selectOption: (optionId: string) => set({ selectedOptionId: optionId }),
+
+    /** 모든 상태를 초기값으로 리셋합니다. */
+    reset: () => set({ mode: "initial", selectedOptionId: null }),
+  },
 }));

--- a/src/stores/avatarCreationStore.ts
+++ b/src/stores/avatarCreationStore.ts
@@ -1,5 +1,15 @@
 import { create } from "zustand";
 
+/**
+ * @interface AvatarCreationState
+ * @description AvatarCreation 컴포넌트의 상태를 관리하는 인터페이스.
+ * @property {string} buttonVariant - 버튼의 변형 스타일 ("primary", "gray200", "gray600")
+ * @property {string} buttonText - 버튼에 표시될 텍스트
+ * @property {function} setButtonState - 버튼 상태를 설정하는 함수 (variant: "primary" | "gray200" | "gray600", text: string)
+ * @property {boolean} isAvatarOptionSelected - 아바타 옵션이 선택되었는지 여부 (true: 선택됨, false: 선택되지 않음)
+ * @property {function} setIsAvatarOptionSelected - 아바타 옵션 선택 상태를 설정하는 함수 (setIsAvatarOptionSelected(true | false))
+ * @example - const { buttonVariant, buttonText, setButtonState, isAvatarOptionSelected, setIsAvatarOptionSelected } = useAvatarCreationStore();
+ */
 interface AvatarCreationState {
   buttonVariant: "primary" | "gray200" | "gray600";
   buttonText: string;
@@ -7,11 +17,22 @@ interface AvatarCreationState {
     variant: "primary" | "gray200" | "gray600",
     text: string
   ) => void;
+  isAvatarOptionSelected: boolean;
+  setIsAvatarOptionSelected: (isSelected: boolean) => void;
 }
 
+/**
+ * @function useAvatarCreationStore
+ * @description AvatarCreation 컴포넌트의 상태를 관리하는 Zustand 스토어 훅.
+ * @returns {AvatarCreationState} AvatarCreation 컴포넌트의 상태와 상태를 변경하는 함수들을 포함하는 객체.
+ * @example - const { buttonVariant, buttonText, setButtonState, isAvatarOptionSelected, setIsAvatarOptionSelected } = useAvatarCreationStore();
+ */
 export const useAvatarCreationStore = create<AvatarCreationState>(set => ({
   buttonVariant: "primary",
   buttonText: "만들러 가기",
   setButtonState: (variant, text) =>
     set({ buttonVariant: variant, buttonText: text }),
+  isAvatarOptionSelected: false,
+  setIsAvatarOptionSelected: (isSelected: boolean) =>
+    set({ isAvatarOptionSelected: isSelected }),
 }));


### PR DESCRIPTION
### 💡 To Reviewers
- 해당 브랜치에서 새롭게 설치한 라이브러리가 있다면 함께 명시해 주세요.
없습니당.

- 리뷰어가 코드를 이해하는 데 도움이 되는 정보나 참고사항이 있다면 자유롭게 작성해 주세요.
1. **`useAvatarCreationStore` (Zustand 스토어)**
`mode`: 현재 플로우가 '최초 생성'(initial)인지 '다시 만들기'(remake)인지를 나타내는 상태입니다.
`selectedOptionId`: 사용자가 선택한 AvatarCreationOption의 고유 ID를 저장합니다. ( 추후 API에 따라 변경합니다. )
`actions`: 상태를 변경하는 함수들을 모아놓은 객체입니다.

2. **컴포넌트의 역할 분리**
`CreationDetailPage`
'다음' 버튼을 누르면 completeInitialCreation 액션을 호출하여 mode를 remake로 변경하는 역할만 합니다.

`AvatarCreationOption`
스토어(useAvatarCreationStore)의 mode와 selectedOptionId를 구독합니다.

`AvatarCreationPage`
스토어의 selectedOptionId 상태를 ButtonFooter로 전달하여 '다음' 버튼의 활성화 여부를 제어


### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
**stores/avatarCreationStore.ts 리팩토링**
- mode와 selectedOptionId를 중심으로 스토어를 재구성
- 액션 함수들을 actions 객체 안에 그룹화

**pages/registration/CreationDetailPage.tsx 수정**
-  handleNextClick 함수를 수정하여 스토어의 completeInitialCreation 액션을 호출하도록 변경

**components/registration/avatarCreation/AvatarCreationOption.tsx 수정**
- 스토어의 mode를 감지하여 두 가지 상태("일반"과 "다시 만들기")를 처리
- "다시 만들기" 모드에서는 클릭 이벤트를 처리
- 자신이 선택되었는지 여부를 스토어의 selectedOptionId와 비교하여 UI에 표시

**pages/registration/AvatarCreationPage.tsx 수정**
-  AvatarCreationOption 컴포넌트에 고유 ID(optionId)를 전달하고, 스토어의 selectedOptionId 상태에 따라 ButtonFooter의 '다음' 버튼 활성화 여부를 결정
- . AvatarCreationPage.tsx를 수정하여 AvatarCreationOption에 optionId를 전달하고, ButtonFooter의 variant를 스토어 상태에 따라 동적으로 변경


### 🤔 추후 작업 예정
- 추가 구현이 필요한 부분이나 다음 작업 계획을 작성해 주세요.
- 별명 짓기 페이지의 ButtonFooter Props 수정
- 아바타 선택 페이지 UI 구현

### 📸 작업 결과 (스크린샷)
- 작업 결과를 보여주는 스크린샷을 첨부해 주세요.

https://github.com/user-attachments/assets/026de3e7-8fd4-46db-9bbd-29cd5e877eb8



### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: #2
#20 