### PR TITLE
fix: 바텀 시트 수정

### DIFF
--- a/src/components/bottom-sheet/BottomSheet.tsx
+++ b/src/components/bottom-sheet/BottomSheet.tsx
@@ -174,19 +174,19 @@ const BottomSheet: React.FC = () => {
   };
   return (
     <div
-      className="fixed inset-0 z-50 overflow-hidden w-full pointer-events-none"
+      className="absolute inset-0 z-50 overflow-hidden w-full pointer-events-none"
       style={{ touchAction: "none" }}
     >
       {/* ✅ 풀 오픈일 때만 백드롭 렌더 */}
       {snapIdx > 0 && (
         <button
-          className="fixed inset-0 pointer-events-auto"
+          className="absolute inset-0 pointer-events-auto"
           onClick={() => snapTo(0)}
         />
       )}
 
       {/* 패널 */}
-      <div className="fixed inset-x-0 bottom-0 flex justify-center z-10 ">
+      <div className="absolute inset-x-0 bottom-0 flex justify-center z-10 ">
         <div
           ref={sheetRef}
           className="pointer-events-auto w-full rounded-t-2xl border-t border-gray-200 bg-white p-2"

--- a/src/components/home/FirstPlant.tsx
+++ b/src/components/home/FirstPlant.tsx
@@ -24,19 +24,26 @@ const FirstPlant = () => {
       {isUnlocked !== "clear" && (
         <>
           <div className="flex-1 flex items-center justify-center w-full">
-            {isUnlocked === "unlock" ? <UnLock /> : <Lock />}
+            {isUnlocked === "unlock" ? (
+              <UnLock>
+                <button
+                  onClick={() => setIsUnlocked("clear")}
+                  className={`m-4 text-white bg-primary p-3 text-body2 rounded-lg`}
+                >
+                  씨앗 받고 해금하기!
+                </button>
+              </UnLock>
+            ) : (
+              <Lock>
+                <button
+                  onClick={() => setIsUnlocked("unlock")}
+                  className={`m-4 text-white bg-gray-400 p-3 text-body2 rounded-lg`}
+                >
+                  충분하지 않아요
+                </button>
+              </Lock>
+            )}
           </div>
-
-          <button
-            onClick={() =>
-              setIsUnlocked(isUnlocked === "lock" ? "unlock" : "clear")
-            }
-            className={`w-full ${isUnlocked === "unlock" ? "bg-primary text-white" : "bg-gray-200 text-gray-400"} h-16 text-heading2`}
-          >
-            {isUnlocked === "lock"
-              ? "아직 감자가 충분히 모이지 않았어요"
-              : "씨앗 받고 해금하기!"}
-          </button>
         </>
       )}
       {isUnlocked === "clear" && (
@@ -49,7 +56,6 @@ const FirstPlant = () => {
             </header>
             <Avatar />
           </div>
-          <BottomSheet />
         </>
       )}
     </div>

--- a/src/components/home/FourthPlant.tsx
+++ b/src/components/home/FourthPlant.tsx
@@ -23,19 +23,26 @@ const FourthPlant = () => {
       {isUnlocked !== "clear" && (
         <>
           <div className="flex-1 flex items-center justify-center w-full">
-            {isUnlocked === "unlock" ? <UnLock /> : <Lock />}
+            {isUnlocked === "unlock" ? (
+              <UnLock>
+                <button
+                  onClick={() => setIsUnlocked("clear")}
+                  className={`m-4 text-white bg-primary p-3 text-body2 rounded-lg`}
+                >
+                  씨앗 받고 해금하기!
+                </button>
+              </UnLock>
+            ) : (
+              <Lock>
+                <button
+                  onClick={() => setIsUnlocked("unlock")}
+                  className={`m-4 text-white bg-gray-400 p-3 text-body2 rounded-lg`}
+                >
+                  충분하지 않아요
+                </button>
+              </Lock>
+            )}
           </div>
-
-          <button
-            onClick={() =>
-              setIsUnlocked(isUnlocked === "lock" ? "unlock" : "clear")
-            }
-            className={`w-full ${isUnlocked === "unlock" ? "bg-primary text-white" : "bg-gray-200 text-gray-400"} h-16 text-heading2`}
-          >
-            {isUnlocked === "lock"
-              ? "아직 감자가 충분히 모이지 않았어요"
-              : "씨앗 받고 해금하기!"}
-          </button>
         </>
       )}
       {isUnlocked === "clear" && (
@@ -48,7 +55,6 @@ const FourthPlant = () => {
             </header>
             <Avatar />
           </div>
-          <BottomSheet />
         </>
       )}
     </div>

--- a/src/components/home/SecondPlant.tsx
+++ b/src/components/home/SecondPlant.tsx
@@ -23,19 +23,26 @@ const SecondPlant = () => {
       {isUnlocked !== "clear" && (
         <>
           <div className="flex-1 flex items-center justify-center w-full">
-            {isUnlocked === "unlock" ? <UnLock /> : <Lock />}
+            {isUnlocked === "unlock" ? (
+              <UnLock>
+                <button
+                  onClick={() => setIsUnlocked("clear")}
+                  className={`m-4 text-white bg-primary p-3 text-body2 rounded-lg`}
+                >
+                  씨앗 받고 해금하기!
+                </button>
+              </UnLock>
+            ) : (
+              <Lock>
+                <button
+                  onClick={() => setIsUnlocked("unlock")}
+                  className={`m-4 text-white bg-gray-400 p-3 text-body2 rounded-lg`}
+                >
+                  충분하지 않아요
+                </button>
+              </Lock>
+            )}
           </div>
-
-          <button
-            onClick={() =>
-              setIsUnlocked(isUnlocked === "lock" ? "unlock" : "clear")
-            }
-            className={`w-full ${isUnlocked === "unlock" ? "bg-primary text-white" : "bg-gray-200 text-gray-400"} h-16 text-heading2`}
-          >
-            {isUnlocked === "lock"
-              ? "아직 감자가 충분히 모이지 않았어요"
-              : "씨앗 받고 해금하기!"}
-          </button>
         </>
       )}
       {isUnlocked === "clear" && (
@@ -48,7 +55,6 @@ const SecondPlant = () => {
             </header>
             <Avatar />
           </div>
-          <BottomSheet />
         </>
       )}
     </div>

--- a/src/components/home/ThirdPlant.tsx
+++ b/src/components/home/ThirdPlant.tsx
@@ -23,19 +23,26 @@ const ThirdPlant = () => {
       {isUnlocked !== "clear" && (
         <>
           <div className="flex-1 flex items-center justify-center w-full">
-            {isUnlocked === "unlock" ? <UnLock /> : <Lock />}
+            {isUnlocked === "unlock" ? (
+              <UnLock>
+                <button
+                  onClick={() => setIsUnlocked("clear")}
+                  className={`m-4 text-white bg-primary p-3 text-body2 rounded-lg`}
+                >
+                  씨앗 받고 해금하기!
+                </button>
+              </UnLock>
+            ) : (
+              <Lock>
+                <button
+                  onClick={() => setIsUnlocked("unlock")}
+                  className={`m-4 text-white bg-gray-400 p-3 text-body2 rounded-lg`}
+                >
+                  충분하지 않아요
+                </button>
+              </Lock>
+            )}
           </div>
-
-          <button
-            onClick={() =>
-              setIsUnlocked(isUnlocked === "lock" ? "unlock" : "clear")
-            }
-            className={`w-full ${isUnlocked === "unlock" ? "bg-primary text-white" : "bg-gray-200 text-gray-400"} h-16 text-heading2`}
-          >
-            {isUnlocked === "lock"
-              ? "아직 감자가 충분히 모이지 않았어요"
-              : "씨앗 받고 해금하기!"}
-          </button>
         </>
       )}
       {isUnlocked === "clear" && (
@@ -48,7 +55,6 @@ const ThirdPlant = () => {
             </header>
             <Avatar />
           </div>
-          <BottomSheet />
         </>
       )}
     </div>

--- a/src/components/lock/Lock.tsx
+++ b/src/components/lock/Lock.tsx
@@ -1,14 +1,16 @@
 import LockIcon from "@/assets/icons/lock.svg?react";
 
-const Lock = () => {
+const Lock = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="flex flex-col w-full h-full items-center justify-center gap-2 bg-white/66 backdrop-blur-sm">
       <LockIcon className="w-8 h-8" />
       <div className="text-heading2 text-danger">아직 해금되지 않았습니다!</div>
       <div className="text-body2 text-black text-center">
-        감자를 충분히 모은 뒤에 <br />
+        소망 나무가 충분히 자라면
+        <br />
         새로운 식물을 키울 수 있어요.
       </div>
+      {children}
     </div>
   );
 };

--- a/src/components/lock/UnLock.tsx
+++ b/src/components/lock/UnLock.tsx
@@ -1,6 +1,6 @@
 import UnLockIcon from "@/assets/icons/unlocked.svg?react";
 
-const Lock = () => {
+const Lock = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="flex flex-col w-full h-full items-center justify-center gap-2 bg-white/66 backdrop-blur-sm">
       <UnLockIcon className="w-8 h-8" />
@@ -9,6 +9,7 @@ const Lock = () => {
         아래 버튼을 눌러 씨앗을 배송받고, <br />
         새로운 곳에서 식물을 키워보세요.
       </div>
+      {children}
     </div>
   );
 };

--- a/src/pages/home/Homepage.tsx
+++ b/src/pages/home/Homepage.tsx
@@ -11,6 +11,7 @@ import ThirdPlant from "@/components/home/ThirdPlant";
 import FourthPlant from "@/components/home/FourthPlant";
 
 import "@/styles/home/swiper.css";
+import BottomSheet from "@/components/bottom-sheet/BottomSheet";
 
 const HomePage = () => {
   const navigate = useNavigate();
@@ -61,6 +62,7 @@ const HomePage = () => {
           <FourthPlant />
         </SwiperSlide>
       </Swiper>
+      <BottomSheet />
     </div>
   );
 };


### PR DESCRIPTION
### 💡 To Reviewers
- 

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- 메인 페이지 리스트 컴포넌트 구현
- 헤더 구현

### 🤔 추후 작업 예정
- 추가 구현이 필요한 부분이나 다음 작업 계획을 작성해 주세요.

### 📸 작업 결과 (스크린샷)
- 작업 결과를 보여주는 스크린샷을 첨부해 주세요.
<img width="532" height="930" alt="스크린샷 2025-08-24 오후 7 25 31" src="https://github.com/user-attachments/assets/048ec249-a81f-475d-ad74-6000cf785fa0" />

바텀 시트 및 버튼 구조 변겨
### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: #49 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 홈 화면에 공통 BottomSheet를 추가해 일관된 하단 패널 경험을 제공합니다.

- 변경 사항
  - 잠금/해금 흐름을 개선하여 각 상태(Lock/UnLock) 내에 행동 버튼을 배치했습니다.
  - 버튼 라벨: “씨앗 받고 해금하기!”, “충분하지 않아요”. 기존 하단 전역 토글 버튼은 제거되었습니다.
  - “clear” 상태에서 카드 내 BottomSheet는 제거되고, 홈 전역 BottomSheet로 일원화되었습니다.
  - 안내 문구를 “소망 나무가 충분히 자라면”으로 업데이트했습니다.

- 스타일
  - BottomSheet 위치 지정 방식을 조정해 오버레이/패널 레이아웃 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->