### PR TITLE
[Feat] API 공통 응답구조 세팅

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,5 +1,6 @@
 // src/lib/api.ts
 import axios, { AxiosError, InternalAxiosRequestConfig } from "axios";
+
 import useTokenStore from "@/stores/useTokenStore";
 
 type RetryConfig = InternalAxiosRequestConfig & { _retry?: boolean };
@@ -79,9 +80,9 @@ api.interceptors.response.use(
         { headers: { Authorization: "" } } // access 필요 없게 강제 제거(백엔드 정책에 맞게 조정)
       );
 
-      // 백엔드 응답 스펙에 맞춰 키 이름 변경 가능
-      const newAccessToken = resp.data.result.result.accessToken;
-      const newRefreshToken = resp.data.result.result.refreshToken;
+      // 공통 응답 래퍼 구조에 맞춰 파싱
+      const newAccessToken = resp.data.result.accessToken;
+      const newRefreshToken = resp.data.result.refreshToken;
 
       if (!newAccessToken) {
         throw new Error("No accessToken in refresh response");

--- a/src/apis/register/registerApi.ts
+++ b/src/apis/register/registerApi.ts
@@ -1,13 +1,12 @@
+import { PostRegisterResponse } from "@/types/apis/register";
+import { ApiResponse } from "@/types/common/apiResponse.type";
+
 import axios from "@/apis/instance";
 
-export const registerApi = async (nickname: string) => {
-  try {
-    const response = await axios.post("/api/v1/auth/signup", {
-      nickname,
-    });
-    return response.data;
-  } catch (error) {
-    alert("회원가입에 실패했습니다.");
-    console.log(error);
-  }
+export const registerApi = async (
+  nickname: string
+): ApiResponse<PostRegisterResponse> => {
+  return axios.post("/api/v1/auth/signup", { nickname }).then(res => res.data);
 };
+
+//APiResponse는 공통 응답 리스폰스 isSuccess, code, message, result

--- a/src/hooks/register/useRegister.ts
+++ b/src/hooks/register/useRegister.ts
@@ -1,0 +1,28 @@
+import axios from "axios";
+import { useNavigate } from "react-router-dom";
+
+import useRegisterApi from "@/hooks/register/useRegisterApi";
+import { ErrorResponse } from "@/types/common/apiResponse.type";
+
+//useRegister는 mutateAsync를 감싸서 에러처리와 라우팅 담당
+
+export const useRegister = () => {
+  const navigate = useNavigate();
+  const { postRegisterMutation } = useRegisterApi();
+
+  const register = async (nickname: string) => {
+    try {
+      await postRegisterMutation.mutateAsync(nickname);
+      navigate("/");
+    } catch (error) {
+      if (axios.isAxiosError<ErrorResponse>(error)) {
+        throw error.response?.data.code;
+      }
+      throw error;
+    }
+  };
+
+  return { register, postRegisterMutation };
+};
+
+export default useRegister;

--- a/src/hooks/register/useRegisterApi.ts
+++ b/src/hooks/register/useRegisterApi.ts
@@ -1,0 +1,30 @@
+import { useMutation } from "@tanstack/react-query";
+
+import useTokenStore from "@/stores/useTokenStore";
+import { PostRegisterResponse } from "@/types/apis/register";
+import { GlobalResponse } from "@/types/common/apiResponse.type";
+
+import { registerApi } from "@/apis/register/registerApi";
+
+// useRegisterApi는 TanStack Query의 useMutation을 정의해서 반환
+
+export const useRegisterApi = () => {
+  const { setAccessToken, setRefreshToken, setUserId } = useTokenStore();
+
+  const postRegisterMutation = useMutation<
+    GlobalResponse<PostRegisterResponse>,
+    unknown,
+    string
+  >({
+    mutationFn: (nickname: string) => registerApi(nickname),
+    onSuccess: res => {
+      setAccessToken(res.result.accessToken);
+      setRefreshToken(res.result.refreshToken);
+      setUserId(String(res.result.userId));
+    },
+  });
+
+  return { postRegisterMutation };
+};
+
+export default useRegisterApi;

--- a/src/pages/register/RegisterPage.tsx
+++ b/src/pages/register/RegisterPage.tsx
@@ -1,17 +1,14 @@
 import { useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 import Edit from "@/assets/icons/common/edit.svg?react";
-import { registerApi } from "@/apis/register/registerApi";
-import useTokenStore from "@/stores/useTokenStore";
+import useRegister from "@/hooks/register/useRegister";
 
 const RegisterPage = () => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [nickname, setNickname] = useState("");
 
-  const { setAccessToken, setRefreshToken, setUserId } = useTokenStore();
-  const navigate = useNavigate();
+  const { register } = useRegister();
 
   const handleWrapperClick = () => {
     // div 클릭 시 input에 포커스
@@ -19,14 +16,7 @@ const RegisterPage = () => {
   };
 
   const handleRegister = async () => {
-    const result = await registerApi(nickname);
-    console.log(result);
-    if (result) {
-      setAccessToken(result.result.accessToken);
-      setRefreshToken(result.result.refreshToken);
-      setUserId(result.result.userId);
-      navigate("/");
-    }
+    await register(nickname);
   };
 
   return (

--- a/src/pages/register/RegisterPage.tsx
+++ b/src/pages/register/RegisterPage.tsx
@@ -8,6 +8,7 @@ const RegisterPage = () => {
 
   const [nickname, setNickname] = useState("");
 
+  // useRegister 훅으로 분리
   const { register } = useRegister();
 
   const handleWrapperClick = () => {

--- a/src/types/apis/register.ts
+++ b/src/types/apis/register.ts
@@ -1,5 +1,7 @@
-export type RegisterType = {
+export type PostRegisterResponse = {
   accessToken: string;
   refreshToken: string;
-  newAccount: boolean;
+  userId: number;
+  nickname: string;
+  newUser: boolean;
 };

--- a/src/types/common/apiResponse.type.ts
+++ b/src/types/common/apiResponse.type.ts
@@ -1,0 +1,15 @@
+export type GlobalResponse<T> = {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: T;
+};
+
+// 응답 Response Type
+export type ApiResponse<T> = Promise<GlobalResponse<T>>;
+
+// 응답 데이터가 없는 경우 (ex. delete)
+export type NoResponse = Record<string, never>;
+
+// 에러 응답
+export type ErrorResponse = GlobalResponse<Record<string, never>>;


### PR DESCRIPTION
### 💡 To Reviewers

1. 
types/common/apiResponse.type.ts에 
공통 응답 타입 정의했습니다.
ApiResponse, NoResponse, ErrorResponse

<img width="1683" height="1168" alt="image" src="https://github.com/user-attachments/assets/d39981f6-7b3b-457c-b0a6-f71acd8d7145" />

2. 
types/common/register.ts에 

유저등록 api에 대한 응답 타입을 PostRegisterResponse로 정의했습니다.

<img width="1610" height="1280" alt="image" src="https://github.com/user-attachments/assets/8bff5ed1-b693-461d-b152-e69ad098f081" />

3.
apis/register/registerApi.ts를 

공통 응답 타입과 PostRegisterResponse 타입을 이용하여 리팩토링하였습니다.
<img width="1626" height="649" alt="image" src="https://github.com/user-attachments/assets/3812b23c-8357-43c2-9a00-b9f082badd60" />

4.
RegisterPage에 있던 api 호출 로직을 
hooks/register/useRegisterApi.ts
hooks/register/useRegister.ts
에 tanstack Query를 사용하여 분리했습니다. (주석 확인)

<img width="1605" height="991" alt="image" src="https://github.com/user-attachments/assets/8c6b6f7d-4cce-4c4c-86e4-7d9d8cbc7eb7" />
<img width="1601" height="1144" alt="image" src="https://github.com/user-attachments/assets/cd85423a-fe59-4ad6-b627-9c959423ab44" />



### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- API 공통 응답 구조 세팅
- Register API 리펙토링

### 🔗 관련 이슈
- #57 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 토큰 갱신 응답 파싱을 표준 구조로 정정하여 자동 재인증/재시도 동작이 더 안정적으로 수행됩니다. 예기치 않은 세션 종료 가능성을 낮췄습니다.
- 리팩터링
  - 회원가입 흐름을 전용 훅으로 분리해 처리 일관성과 안정성을 강화했습니다. UI 변화 없이 성공 시 자동 이동과 토큰 저장이 더 견고해졌으며, 오류 상황에서 더 명확한 안내가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->