### PR TITLE
[Refactor] 아바타 생성/선택 및 퀴즈 타입 리팩토링

### DIFF
--- a/src/apis/avatars/avatarApi.ts
+++ b/src/apis/avatars/avatarApi.ts
@@ -10,28 +10,28 @@ import { ApiResponse, GlobalResponse } from "@/types/common/apiResponse.type";
 
 import axios from "@/apis/instance";
 
-export const getSelectionAvatarApi = async (): ApiResponse<AvatarType[]> => {
+export const getSelectionAvatarApi = async (): ApiResponse<AvatarType> => {
   return axios.get("/api/v1/avatars/masters").then(res => res.data);
 };
 
 export const postCrationAvatarApi = async (
   formData: FormData
-): Promise<CreateAvatarResponse> => {
+): ApiResponse<CreateAvatarResponse> => {
   try {
-    const response = await Axios.post(
+    const response = await Axios.post<GlobalResponse<CreateAvatarResponse>>(
       "http://43.200.84.255:8000/process-image",
       formData
     );
     return response.data;
   } catch (error) {
-    console.error("error :", error);
+    console.error("이미지 생성 실패:", error);
     throw error;
   }
 };
 
 export const finalChoiceAvatarApi = async (
   data: FinalChoiceAvatarRequest
-): Promise<GlobalResponse<FinalChoiceAvatarResponse>> => {
+): ApiResponse<FinalChoiceAvatarResponse> => {
   try {
     const response = await axios.post<
       GlobalResponse<FinalChoiceAvatarResponse>

--- a/src/apis/avatars/avatarApi.ts
+++ b/src/apis/avatars/avatarApi.ts
@@ -5,17 +5,13 @@ import {
   FinalChoiceAvatarRequest,
   FinalChoiceAvatarResponse,
 } from "@/types/avatars/masters";
+import { AvatarType } from "@/types/avatars/masters";
+import { ApiResponse, GlobalResponse } from "@/types/common/apiResponse.type";
 
 import axios from "@/apis/instance";
 
-export const getSelectionAvatarApi = async () => {
-  try {
-    const response = await axios.get("/api/v1/avatars/masters");
-    return response.data;
-  } catch (error) {
-    alert("회원가입에 실패했습니다.");
-    console.log(error);
-  }
+export const getSelectionAvatarApi = async (): ApiResponse<AvatarType[]> => {
+  return axios.get("/api/v1/avatars/masters").then(res => res.data);
 };
 
 export const postCrationAvatarApi = async (
@@ -35,12 +31,11 @@ export const postCrationAvatarApi = async (
 
 export const finalChoiceAvatarApi = async (
   data: FinalChoiceAvatarRequest
-): Promise<FinalChoiceAvatarResponse> => {
+): Promise<GlobalResponse<FinalChoiceAvatarResponse>> => {
   try {
-    const response = await axios.post<FinalChoiceAvatarResponse>(
-      "/api/v1/avatars",
-      data
-    );
+    const response = await axios.post<
+      GlobalResponse<FinalChoiceAvatarResponse>
+    >("/api/v1/avatars", data);
     return response.data;
   } catch (error) {
     console.error("아바타 선택 실패:", error);

--- a/src/apis/missions/QuizApi.ts
+++ b/src/apis/missions/QuizApi.ts
@@ -1,5 +1,8 @@
-import { ApiResponse } from "@/types/common/apiResponse.type";
-import { AnswerQuizResponse } from "@/types/realQuiz/answerQuiz";
+import { ApiResponse, GlobalResponse } from "@/types/common/apiResponse.type";
+import {
+  AnswerQuizRequest,
+  AnswerQuizResponse,
+} from "@/types/realQuiz/answerQuiz";
 import { getQuizRequest, getQuizResponse } from "@/types/realQuiz/getQuiz";
 
 import axios from "@/apis/instance";
@@ -13,18 +16,17 @@ export const getQuizApi = async (
 export const postAnswerQuizApi = async ({
   selectedOptionOrder,
   quizId,
-}: {
-  selectedOptionOrder: number;
-  quizId: number;
-}): Promise<AnswerQuizResponse> => {
+}: AnswerQuizRequest & { quizId: number }): Promise<
+  GlobalResponse<AnswerQuizResponse>
+> => {
   try {
-    const response = await axios.post<AnswerQuizResponse>(
+    const response = await axios.post<GlobalResponse<AnswerQuizResponse>>(
       `/api/v1/realQuiz/${quizId}/answer`,
       { selectedOptionOrder }
     );
     return response.data;
   } catch (error) {
-    console.error("Error post Answer Quiz:", error);
+    console.error("퀴즈 답안 제출 실패:", error);
     throw error;
   }
 };

--- a/src/apis/missions/QuizApi.ts
+++ b/src/apis/missions/QuizApi.ts
@@ -1,3 +1,4 @@
+import { ApiResponse } from "@/types/common/apiResponse.type";
 import { AnswerQuizResponse } from "@/types/realQuiz/answerQuiz";
 import { getQuizRequest, getQuizResponse } from "@/types/realQuiz/getQuiz";
 
@@ -5,15 +6,8 @@ import axios from "@/apis/instance";
 
 export const getQuizApi = async (
   params: getQuizRequest
-): Promise<getQuizResponse> => {
-  try {
-    const response = await axios.get("/api/v1/realQuiz", { params });
-
-    return response.data;
-  } catch (error) {
-    console.error("Error get MissionPanel:", error);
-    throw error;
-  }
+): ApiResponse<getQuizResponse> => {
+  return axios.get("/api/v1/realQuiz", { params }).then(res => res.data);
 };
 
 export const postAnswerQuizApi = async ({

--- a/src/apis/missions/writeDiaryApi.ts
+++ b/src/apis/missions/writeDiaryApi.ts
@@ -19,11 +19,4 @@ export const writeDiarySubmitApi = async (
   params: writeDiarySubmitRequest
 ): ApiResponse<writeDiarySubmitResponse> => {
   return axios.post("api/v1/diaries", params).then(res => res.data);
-  // try {
-  //   const response = await axios.post("/api/v1/diaries", params);
-  //   return response.data;
-  // } catch (error) {
-  //   console.error("Error post WriteDiarySubmit:", error);
-  //   throw error;
-  // }
 };

--- a/src/apis/missions/writeDiaryApi.ts
+++ b/src/apis/missions/writeDiaryApi.ts
@@ -1,3 +1,4 @@
+import { ApiResponse } from "@/types/common/apiResponse.type";
 import {
   writeDiaryImageUploadResponse,
   writeDiarySubmitRequest,
@@ -7,26 +8,22 @@ import {
 import axios from "@/apis/instance";
 
 // 이미지 전송 API
-export const takePhotoUploadApi = async (
+
+export const takePhotoUploadApi = (
   formData: FormData
-): Promise<writeDiaryImageUploadResponse> => {
-  try {
-    const response = await axios.post("/api/v1/diaries/images", formData);
-    return response.data;
-  } catch (error) {
-    console.error("Error post TakePhotoUpload:", error);
-    throw error;
-  }
+): ApiResponse<writeDiaryImageUploadResponse> => {
+  return axios.post("/api/v1/diaries/images", formData).then(res => res.data);
 };
 
 export const writeDiarySubmitApi = async (
   params: writeDiarySubmitRequest
-): Promise<writeDiarySubmitResponse> => {
-  try {
-    const response = await axios.post("/api/v1/diaries", params);
-    return response.data;
-  } catch (error) {
-    console.error("Error post WriteDiarySubmit:", error);
-    throw error;
-  }
+): ApiResponse<writeDiarySubmitResponse> => {
+  return axios.post("api/v1/diaries", params).then(res => res.data);
+  // try {
+  //   const response = await axios.post("/api/v1/diaries", params);
+  //   return response.data;
+  // } catch (error) {
+  //   console.error("Error post WriteDiarySubmit:", error);
+  //   throw error;
+  // }
 };

--- a/src/hooks/avatars/useFinalChoiceAvatarApi.ts
+++ b/src/hooks/avatars/useFinalChoiceAvatarApi.ts
@@ -1,25 +1,28 @@
 import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 
 import {
   FinalChoiceAvatarRequest,
   FinalChoiceAvatarResponse,
 } from "@/types/avatars/masters";
+import { ErrorResponse, GlobalResponse } from "@/types/common/apiResponse.type";
 
 import { finalChoiceAvatarApi } from "@/apis/avatars/avatarApi";
 
 export const useFinalChoiceAvatar = () => {
   return useMutation<
-    FinalChoiceAvatarResponse,
-    Error,
+    GlobalResponse<FinalChoiceAvatarResponse>,
+    AxiosError<ErrorResponse>,
     FinalChoiceAvatarRequest
   >({
     mutationFn: data => finalChoiceAvatarApi(data),
     onSuccess: data => {
-      console.log("아바타 최종 선택 성공:", data);
+      console.log("아바타 최종 선택 성공:", data.result);
     },
     onError: error => {
       alert("아바타 최종 선택에 실패했습니다.");
-      console.error(error);
+      console.error(error.response?.data || error.message);
     },
+    retry: 1,
   });
 };

--- a/src/hooks/avatars/useGetSelectAvatarApi.ts
+++ b/src/hooks/avatars/useGetSelectAvatarApi.ts
@@ -1,12 +1,23 @@
 import { useQuery } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 
-import { SelectAvatarResponse } from "@/types/avatars/masters";
+import { AvatarType } from "@/types/avatars/masters";
+import { ErrorResponse, GlobalResponse } from "@/types/common/apiResponse.type";
 
 import { getSelectionAvatarApi } from "@/apis/avatars/avatarApi";
 
 export const useGetSelectAvatar = () => {
-  return useQuery<SelectAvatarResponse, Error>({
+  return useQuery<
+    GlobalResponse<AvatarType[]>,
+    AxiosError<ErrorResponse>,
+    AvatarType[]
+  >({
     queryKey: ["selectionAvatar"],
     queryFn: getSelectionAvatarApi,
+    select: data => data.result,
+    staleTime: 1000 * 60 * 120,
+    gcTime: 1000 * 60 * 5,
+    retry: 1,
+    refetchOnWindowFocus: true,
   });
 };

--- a/src/hooks/mission/useGetQuizApi.ts
+++ b/src/hooks/mission/useGetQuizApi.ts
@@ -1,13 +1,21 @@
 import { useQuery } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 
+import { ApiResponse, ErrorResponse } from "@/types/common/apiResponse.type";
 import { getQuizRequest, getQuizResponse } from "@/types/realQuiz/getQuiz";
 
 import { getQuizApi } from "@/apis/missions/QuizApi";
 
 export const useGetQuiz = (params: getQuizRequest) => {
-  return useQuery<getQuizResponse>({
+  return useQuery<
+    ApiResponse<getQuizResponse>, // 서버 전체 응답 타입
+    AxiosError<ErrorResponse>, // Axios 확장 에러 타입
+    getQuizResponse // select로 실제 사용할 데이터 타입
+  >({
     queryKey: ["quiz", params],
-
     queryFn: () => getQuizApi(params),
+    staleTime: 1000 * 60 * 5, // 5분 동안 stale 처리 안함
+    retry: 1, // 실패 시 1번 재시도
+    refetchOnWindowFocus: false, // 창 포커스 시 재요청 X
   });
 };

--- a/src/hooks/mission/usePostAnswerQuiz.ts
+++ b/src/hooks/mission/usePostAnswerQuiz.ts
@@ -1,5 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 
+import { ErrorResponse, GlobalResponse } from "@/types/common/apiResponse.type";
 import { AnswerQuizResponse } from "@/types/realQuiz/answerQuiz";
 
 import { postAnswerQuizApi } from "@/apis/missions/QuizApi";
@@ -10,8 +12,21 @@ interface AnswerQuizParams {
 }
 
 export const useAnswerQuiz = () => {
-  return useMutation<AnswerQuizResponse, Error, AnswerQuizParams>({
-    mutationFn: ({ quizId, selectedOptionOrder }) =>
+  return useMutation<
+    GlobalResponse<AnswerQuizResponse>, // 성공 응답 타입
+    AxiosError<ErrorResponse>, // 에러 타입
+    AnswerQuizParams // 요청 파라미터 타입
+  >({
+    mutationFn: ({ quizId, selectedOptionOrder }: AnswerQuizParams) =>
       postAnswerQuizApi({ quizId, selectedOptionOrder }),
+    onSuccess: data => {
+      console.log("퀴즈 답안 제출 성공:", data.result);
+    },
+    onError: error => {
+      console.error(
+        "퀴즈 답안 제출 실패:",
+        error.response?.data || error.message
+      );
+    },
   });
 };

--- a/src/hooks/mission/useWriteDiaryApi.ts
+++ b/src/hooks/mission/useWriteDiaryApi.ts
@@ -1,7 +1,10 @@
 // src/hooks/mission/useWriteDiaryApi.ts
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 
+import { ErrorResponse, GlobalResponse } from "@/types/common/apiResponse.type";
 import {
+  WriteDiaryImageUploadRequest,
   writeDiaryImageUploadResponse,
   writeDiarySubmitRequest,
   writeDiarySubmitResponse,
@@ -16,20 +19,21 @@ export const useWriteDiaryImageUploadApi = () => {
   const queryClient = useQueryClient();
 
   return useMutation<
-    writeDiaryImageUploadResponse,
-    Error,
-    { formData: FormData }
+    GlobalResponse<writeDiaryImageUploadResponse>,
+    AxiosError<ErrorResponse>,
+    WriteDiaryImageUploadRequest
   >({
     mutationFn: ({ formData }) => takePhotoUploadApi(formData),
-    onSuccess: data => {
-      console.log("일기 사진 업로드 성공:", data);
-
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["diaries"] });
     },
-
     onError: error => {
-      console.error("일기 사진 업로드 실패:", error);
+      console.error(
+        "이미지 업로드 실패:",
+        error.response?.data || error.message
+      );
     },
+    retry: 1,
   });
 };
 
@@ -37,9 +41,9 @@ export const useWriteDiarySubmitApi = () => {
   const queryClient = useQueryClient();
 
   return useMutation<
-    writeDiarySubmitResponse, // 성공 응답 타입
-    Error, // 에러 타입
-    writeDiarySubmitRequest // 요청 타입
+    GlobalResponse<writeDiarySubmitResponse>,
+    AxiosError<ErrorResponse>,
+    writeDiarySubmitRequest
   >({
     mutationFn: body => writeDiarySubmitApi(body),
     onSuccess: data => {
@@ -48,7 +52,7 @@ export const useWriteDiarySubmitApi = () => {
       queryClient.invalidateQueries({ queryKey: ["diaries"] });
     },
     onError: error => {
-      console.error("일기 작성 실패:", error);
+      console.error("일기 작성 실패:", error.response?.data || error.message);
     },
   });
 };

--- a/src/pages/registration/SelectionDetailPage.tsx
+++ b/src/pages/registration/SelectionDetailPage.tsx
@@ -17,15 +17,15 @@ const SelectionDetailPage = () => {
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
   useEffect(() => {
-    if (data?.result && data.result.length > 0 && selectedId === null) {
-      setSelectedId(data.result[0].id);
+    if (data && data.length > 0 && selectedId === null) {
+      setSelectedId(data[0].id);
     }
   }, [data, selectedId]);
 
   const handleNextClick = () => {
-    if (selectedId === null || !data?.result) return;
+    if (selectedId === null || !data) return;
 
-    const selectedAvatar = data.result.find(
+    const selectedAvatar = data.find(
       (avatar: AvatarType) => avatar.id === selectedId
     );
 
@@ -61,10 +61,10 @@ const SelectionDetailPage = () => {
       <div className="text-heading1 pt-8 pl-6.25">
         원하는 아바타를 선택해주세요.
       </div>
-      <main className="flex-1 ">
-        {data?.result && selectedId !== null && (
+      <main className="flex-1">
+        {data && selectedId !== null && (
           <SelectionDetail
-            avatars={data.result}
+            avatars={data}
             selectedId={selectedId}
             onSelect={setSelectedId}
           />

--- a/src/types/avatars/masters.ts
+++ b/src/types/avatars/masters.ts
@@ -1,15 +1,8 @@
+// 아바타 선택하기 조회 API 응답 타입
 export interface AvatarType {
   id: number;
   defaultImageUrl: string;
   description: string;
-}
-
-// 아바타 선택하기 조회 API 응답 타입
-export interface SelectAvatarResponse {
-  isSuccess: boolean;
-  code: string;
-  message: string;
-  result: AvatarType[];
 }
 
 // 아바타 생성하기 응답 타입
@@ -24,9 +17,4 @@ export interface FinalChoiceAvatarRequest {
   masterId: number;
 }
 
-export interface FinalChoiceAvatarResponse {
-  isSuccess: boolean;
-  code: string;
-  message: string;
-  result: string;
-}
+export type FinalChoiceAvatarResponse = string;

--- a/src/types/mission/writeDiary.ts
+++ b/src/types/mission/writeDiary.ts
@@ -1,12 +1,11 @@
-export interface writeDiaryImageUploadResponse {
-  isSuccess: boolean;
-  code: string;
-  message: string;
-  result: {
-    imageId: number;
-    imageUrl: string;
-  };
+export interface WriteDiaryImageUploadRequest {
+  formData: FormData;
 }
+
+export type writeDiaryImageUploadResponse = {
+  imageId: number;
+  imageUrl: string;
+};
 
 export interface writeDiarySubmitRequest {
   title: string;
@@ -17,17 +16,12 @@ export interface writeDiarySubmitRequest {
 }
 
 export interface writeDiarySubmitResponse {
-  isSuccess: boolean;
-  code: string;
-  message: string;
-  result: {
-    diaryId: number;
-    title: string;
-    content: string;
-    imageUrl: string;
-    likeCount: number;
-    createdAt: string;
-    updatedAt: string;
-    public: boolean;
-  };
+  diaryId: number;
+  title: string;
+  content: string;
+  imageUrl: string;
+  likeCount: number;
+  createdAt: string;
+  updatedAt: string;
+  public: boolean;
 }

--- a/src/types/realQuiz/answerQuiz.ts
+++ b/src/types/realQuiz/answerQuiz.ts
@@ -3,16 +3,11 @@ export interface AnswerQuizRequest {
 }
 
 export interface AnswerQuizResponse {
-  isSuccess: boolean;
-  code: string;
-  message: string;
-  result: {
-    quizQuestion: string;
-    quizType: "OX" | "MULTI_CHOICE";
-    selectedOptionNumber: number;
-    answerNumber: number;
-    answerDescription: string;
-    isCorrect: boolean;
-    isCompleted: boolean;
-  };
+  quizQuestion: string;
+  quizType: "OX" | "MULTI_CHOICE";
+  selectedOptionNumber: number;
+  answerNumber: number;
+  answerDescription: string;
+  isCorrect: boolean;
+  isCompleted: boolean;
 }

--- a/src/types/realQuiz/getQuiz.ts
+++ b/src/types/realQuiz/getQuiz.ts
@@ -3,23 +3,18 @@ export interface getQuizRequest {
 }
 
 export interface getQuizResponse {
-  isSuccess: boolean;
-  code: string;
-  message: string;
-  result: {
-    quizId: number;
-    quizQuestion: string;
-    quizType: "OX" | "MULTI_CHOICE" | "CHOICE_WITH_PICTURE";
-    answerNumber: number | null;
-    answerDescription: string | null;
-    isCompleted: boolean;
-    quizOptions:
-      | [
-          {
-            optionOrder: number;
-            optionText: string;
-          },
-        ]
-      | null;
-  };
+  quizId: number;
+  quizQuestion: string;
+  quizType: "OX" | "MULTI_CHOICE" | "CHOICE_WITH_PICTURE";
+  answerNumber: number | null;
+  answerDescription: string | null;
+  isCompleted: boolean;
+  quizOptions:
+    | [
+        {
+          optionOrder: number;
+          optionText: string;
+        },
+      ]
+    | null;
 }


### PR DESCRIPTION
### 💡 To Reviewers
- 해당 브랜치에서 새롭게 설치한 라이브러리가 있다면 함께 명시해 주세요.
없습니다.

- 리뷰어가 코드를 이해하는 데 도움이 되는 정보나 참고사항이 있다면 자유롭게 작성해 주세요.
`src/types/common/apiResponse.type.ts` 의 코드를 참고하여 타입들을 리팩토링 했습니다.

### 🔥 작업 내용 (가능한 구체적으로 작성해 주세요)
- `src/types/avatars/masters.ts`의 타입들 수정 (ApiResponse, GlobalResponse 사용을 위함) -> `src/apis/avatars/avatarApis` -> `src/hooks/avatars` 의 hook들 type들도 수정.
Ex)
<img width="778" height="84" alt="image" src="https://github.com/user-attachments/assets/caf41a03-29b7-40f7-8c8d-13aab7f65ecc" />

- `src/types/mission/writeDiary.ts`의 타입들 수정 (ApiResponse, GlobalResponse 사용을 위함) -> `src/apis/mission/avatarApis` -> `src/hooks/mission` 의 hook들 type들도 수정.


### 🤔 추후 작업 예정
- 추가 구현이 필요한 부분이나 다음 작업 계획을 작성해 주세요.
- UI 틀 수정.. ?

### 📸 작업 결과 (스크린샷)
- 작업 결과를 보여주는 스크린샷을 첨부해 주세요.
- **avatar.ts**
<img width="857" height="88" alt="image" src="https://github.com/user-attachments/assets/4b6b92a5-3b66-4eb3-88d0-0249655464ba" />
<img width="789" height="124" alt="image" src="https://github.com/user-attachments/assets/41bafada-8779-4209-bb34-91de2474afb1" />
<img width="533" height="327" alt="image" src="https://github.com/user-attachments/assets/d0366c8b-6e04-42e2-847c-4a112bdf8292" />


### 🔗 관련 이슈
- 브랜치 생성 시 연결했던 이슈 번호를 작성해 주세요.
- 예: #82 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 아바타/퀴즈/일기 API 응답 포맷을 일관된 래퍼 형태로 표준화하고 데이터 구조를 평탄화해 화면 데이터 처리 단순화
  - 관련 훅 전반에 오류 타입 정교화 및 선택(Select) 단계에서 결과만 노출하도록 정리
- 개선
  - 일부 요청에 자동 재시도(1회) 추가로 네트워크 일시 오류에 대한 안정성 향상
  - 오류 메시지를 한국어로 명확화하여 문제 파악 용이
  - 일기 이미지 업로드 후 목록 캐시를 항상 갱신해 최신 상태 보장
- UI
  - 아바타 선택 상세 페이지가 즉시 배열 데이터를 사용해 로딩/선택 흐름을 간소화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->